### PR TITLE
fix: all fixes

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -2,18 +2,19 @@ name: fresh_ape_test
 
 plugins:
   - name: solidity
-    version: ">=0.6.0 <0.9.0"
   - name: hardhat
-    version: "0.8.1"
   - name: etherscan
-    version: "0.8.2"
   - name: foundry
-    version: "0.8.4"
 
 dependencies:
   - name: uniswap-core
-    github: Uniswap/v3-core/contracts
-    version: 1.0.0
+    github: Uniswap/v3-core
+    ref: v1.0.0
   - name: uniswap-periphery
-    github: Uniswap/v3-periphery/contracts
-    version: 1.3.0
+    github: Uniswap/v3-periphery
+    ref: v1.3.0
+    config_override:
+      dependencies:
+        - name: openzeppelin
+          github: OpenZeppelin/openzeppelin-contracts
+          version: 3.4.2

--- a/contracts/interfaces/IUniswapV3Staker.sol
+++ b/contracts/interfaces/IUniswapV3Staker.sol
@@ -6,8 +6,8 @@ import '@uniswap-core/contracts/interfaces/IUniswapV3Factory.sol';
 import '@uniswap-core/contracts/interfaces/IUniswapV3Pool.sol';
 import '@uniswap-core/contracts/interfaces/IERC20Minimal.sol';
 
-import '@uniswap-periphery/v3-periphery/contracts/interfaces/INonfungiblePositionManager.sol';
-import '@uniswap-periphery/v3-periphery/contracts/interfaces/IMulticall.sol';
+import '@uniswap-periphery/contracts/interfaces/INonfungiblePositionManager.sol';
+import '@uniswap-periphery/contracts/interfaces/IMulticall.sol';
 
 /**
  * @title ERC721 token receiver interface


### PR DESCRIPTION
Changes made to get it work:

1. solidity plugin config had version of solc and not the plugin. no need to specify versions here right now, so removed.
2. Github key in the dependencies included contracts/ at the end. This is supposed to be the github org/repo and nothing else.
3. Use ref + v prefix since the bug we found was happened when using version for a reference. However, we fixed that bug here https://github.com/ApeWorX/ape/pull/2286 but it is still better to use `ref:` when you are using a reference-based GitHub dependency
4. the import statements for v3-periphery were wrong, not sure what was going on there
5. Had to configure the openzeppelin version in the v3-periphery dependency because Ape is bad at detecting stuff from Hardhat projects at this time (we are working on that!)